### PR TITLE
TU Kaiserslautern -> U of Kaiserslautern-Landau

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,8 +193,8 @@ At Uppsala Universitet Prof. <b>Christian Glaser</b><br/>
 At TU-M&uuml;nchen, Prof. <b>Lukas Heinrich</b> and Mr. <b>Max Lamparth</b><br/>
 At Durham University Dr. <b>Patrick Stowell</b><br/>
 At Lebanese University Prof. <b>Haitham Zaraket</b><br/>
-At Technische Università&euml;t Kaiserslautern Mr. <b>Max Aehle</b>, Prof. <b>Nicolas Gauger</b>, Dr. <b>Lisa Kusch</b><br/>
-At Technische Università&euml;t Worms Prof. <b>Ralf Keidel</b><br/>
+At University of Kaiserslautern-Landau Mr. <b>Max Aehle</b>, Prof. <b>Nicolas Gauger</b>, Dr. <b>Lisa Kusch</b><br/>
+At University of Applied Sciences Worms Prof. <b>Ralf Keidel</b><br/>
 At Princeton University Prof. <b>Peter Elmer</b><br/>
 At University of Washington Prof. <b>Gordon Watts</b><br/>
 At SLAC Dr. <b>Ryan Roussel</b>


### PR DESCRIPTION
after official restructuring on January 1st, 2023. Also, fixed English name of Hochschule Worms.